### PR TITLE
Remove all Dvd Drives on Generation 1

### DIFF
--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -171,6 +171,17 @@ Remove-VMDvdDrive -VMName $vmName -ControllerNumber $controllerNumber -Controlle
 	return err
 }
 
+func DeleteAllDvdDrives(vmName string) error {
+	var script = `
+param([string]$vmName)
+Get-VMDvdDrive -VMName $vmName | Remove-VMDvdDrive
+`
+
+	var ps powershell.PowerShellCmd
+	err := ps.Run(script, vmName)
+	return err
+}
+
 func MountFloppyDrive(vmName string, path string) error {
 	var script = `
 param([string]$vmName, [string]$path)
@@ -220,7 +231,7 @@ New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHD
 			return err
 		}
 
-		return DeleteDvdDrive(vmName, 1, 0)
+		return DeleteAllDvdDrives(vmName)
 	}
 }
 


### PR DESCRIPTION
In this code, instead of asking for a specific controller/location, we just remove all Dvd Drives.
It seems like on Windows 2012R2, generation 1 Virtual Machines have their default Dvd on 1,0
while on Windows 10, they have it on 1,1.
