### PR TITLE
Don't do anything if there are no scanCodes

### DIFF
--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -659,6 +659,9 @@ if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running) {
 }
 
 func TypeScanCodes(vmName string, scanCodes string) error {
+	if len(scanCodes) == 0 {
+		return nil
+	}
 	var script = `
 param([string]$vmName, [string]$scanCodes)
 	#Requires -Version 3


### PR DESCRIPTION
That does not solve the underlying issue with accessing the VM console on Windows 10, but at least if there are no scan codes in packer.json, the box creation process can succeed.
