### PR TITLE
Fails at ``Enabling Integration Service...`` step on non-English desktop

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -76,7 +76,7 @@ type Driver interface {
 
 	SetSecureBoot(string, bool) error
 
-	EnableVirtualMachineIntegrationService(string, string) error
+	EnableAllVirtualMachineIntegrationServices(string) error
 
 	ExportVirtualMachine(string, string) error
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -185,8 +185,8 @@ func (d *HypervPS4Driver) SetSecureBoot(vmName string, enable bool) error {
 	return hyperv.SetSecureBoot(vmName, enable)
 }
 
-func (d *HypervPS4Driver) EnableVirtualMachineIntegrationService(vmName string, integrationServiceName string) error {
-	return hyperv.EnableVirtualMachineIntegrationService(vmName, integrationServiceName)
+func (d *HypervPS4Driver) EnableAllVirtualMachineIntegrationServices(vmName string) error {
+	return hyperv.EnableAllVirtualMachineIntegrationServices(vmName)
 }
 
 func (d *HypervPS4Driver) ExportVirtualMachine(vmName string, path string) error {

--- a/builder/hyperv/common/step_enable_integration_service.go
+++ b/builder/hyperv/common/step_enable_integration_service.go
@@ -10,9 +10,7 @@ import (
 	"github.com/mitchellh/packer/packer"
 )
 
-type StepEnableIntegrationService struct {
-	name string
-}
+type StepEnableIntegrationService struct{}
 
 func (s *StepEnableIntegrationService) Run(state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
@@ -20,9 +18,8 @@ func (s *StepEnableIntegrationService) Run(state multistep.StateBag) multistep.S
 	ui.Say("Enabling Integration Service...")
 
 	vmName := state.Get("vmName").(string)
-	s.name = "Guest Service Interface"
 
-	err := driver.EnableVirtualMachineIntegrationService(vmName, s.name)
+	err := driver.EnableAllVirtualMachineIntegrationServices(vmName)
 
 	if err != nil {
 		err := fmt.Errorf("Error enabling Integration Service: %s", err)

--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -470,15 +470,15 @@ if ($vm.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running) {
 	return err
 }
 
-func EnableVirtualMachineIntegrationService(vmName string, integrationServiceName string) error {
+func EnableAllVirtualMachineIntegrationServices(vmName string) error {
 
 	var script = `
-param([string]$vmName,[string]$integrationServiceName)
-Enable-VMIntegrationService -VMName $vmName -Name $integrationServiceName
+param([string]$vmName)
+Get-VMIntegrationService -VMName $vmName | Enable-VMIntegrationService
 `
 
 	var ps powershell.PowerShellCmd
-	err := ps.Run(script, vmName, integrationServiceName)
+	err := ps.Run(script, vmName)
 	return err
 }
 


### PR DESCRIPTION
`Enable-VMIntegrationService` cmdlet recognizes language dependent value for `-Name` option. `builder/hyperv/common/step_enable_integration_service.go` sets the English constant value `Guest Service Interface`. This lets `hyperv-iso` builder crash on my Japanese desktop.

My laptop basic information is as follows:

```
PS C:\> Get-CimInstance Win32_OperatingSystem | Select-Object  Caption, Version, OSType, ServicePackMajorVersion, OSAr
itecture, BuildNumber, MUILanguages, OSLanguage, Locale, CodeSet, CountryCode | FL


Caption                 : Microsoft Windows 10 Pro
Version                 : 10.0.10586
OSType                  : 18
ServicePackMajorVersion : 0
OSArchitecture          : 64 ビット
BuildNumber             : 10586
MUILanguages            : {ja-JP}
OSLanguage              : 1041
Locale                  : 0411
CodeSet                 : 932
CountryCode             : 81


PS C:\> $host


Name             : ConsoleHost
Version          : 5.0.10586.494
InstanceId       : 3f742cac-9dc6-41f4-a811-325ae8b76cec
UI               : System.Management.Automation.Internal.Host.InternalHostUserInterface
CurrentCulture   : ja-JP
CurrentUICulture : ja-JP
PrivateData      : Microsoft.PowerShell.ConsoleHost+ConsoleColorProxy
DebuggerEnabled  : True
IsRunspacePushed : False
Runspace         : System.Management.Automation.Runspaces.LocalRunspace
```

`Enable-VMIntegrationService` with English value failed when `CurrentCulture` configuration is `ja-JP`. (Sorry for the message is in Japanese.)

```
PS C:\> Enable-VMIntegrationService -VMName myvm -Name "Guest Service Interface"
Enable-VMIntegrationService : 指定された名前の統合コンポーネントが見つかりませんでした。
発生場所 行:1 文字:1
+ Enable-VMIntegrationService -VMName myvm -Name "Guest Service Interf ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Enable-VMIntegrationService]、VirtualizationException
    + FullyQualifiedErrorId : InvalidParameter,Microsoft.HyperV.PowerShell.Commands.EnableVMIntegrationService
```

But no issues with Japanese translated value is passed.

```
PS C:\> Enable-VMIntegrationService -VMName myvm -Name "ゲスト サービス インターフェイス"
```

This change proposes that the method `EnableVirtualMachineIntegrationService(string, string)` switch all VM integration services at a time not for selective item.  
