### PR TITLE
Support nested Hyper-V in Packer

### DIFF
--- a/builder/hyperv/common/driver.go
+++ b/builder/hyperv/common/driver.go
@@ -72,7 +72,7 @@ type Driver interface {
 
 	DeleteVirtualMachine(string) error
 
-	SetVirtualMachineCpu(string, uint) error
+	SetVirtualMachineCpu(string, uint, bool) error
 
 	SetSecureBoot(string, bool) error
 

--- a/builder/hyperv/common/driver_ps_4.go
+++ b/builder/hyperv/common/driver_ps_4.go
@@ -177,8 +177,8 @@ func (d *HypervPS4Driver) DeleteVirtualMachine(vmName string) error {
 	return hyperv.DeleteVirtualMachine(vmName)
 }
 
-func (d *HypervPS4Driver) SetVirtualMachineCpu(vmName string, cpu uint) error {
-	return hyperv.SetVirtualMachineCpu(vmName, cpu)
+func (d *HypervPS4Driver) SetVirtualMachineCpu(vmName string, cpu uint, exposeVirtualizationExtensions bool) error {
+	return hyperv.SetVirtualMachineCpu(vmName, cpu, exposeVirtualizationExtensions)
 }
 
 func (d *HypervPS4Driver) SetSecureBoot(vmName string, enable bool) error {

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -22,7 +22,7 @@ type StepCreateVM struct {
 	Generation      uint
 	Cpu             uint
 	EnableSecureBoot bool
-	ExposeVirtualizationExtensions bool
+	EnableVirtualizationExtensions bool
 }
 
 func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
@@ -47,7 +47,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	err = driver.SetVirtualMachineCpu(s.VMName, s.Cpu, s.ExposeVirtualizationExtensions)
+	err = driver.SetVirtualMachineCpu(s.VMName, s.Cpu, s.EnableVirtualizationExtensions)
 	if err != nil {
 		err := fmt.Errorf("Error creating setting virtual machine cpu: %s", err)
 		state.Put("error", err)

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -21,7 +21,7 @@ type StepCreateVM struct {
 	DiskSize        uint
 	Generation      uint
 	Cpu             uint
-	EnabeSecureBoot bool
+	EnableSecureBoot bool
 }
 
 func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
@@ -36,7 +36,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	diskSize := int64(s.DiskSize * 1024 * 1024)
 
 	switchName := s.SwitchName
-	enabeSecureBoot := s.EnabeSecureBoot
+	enableSecureBoot := s.EnableSecureBoot
 
 	err := driver.CreateVirtualMachine(s.VMName, path, ram, diskSize, switchName, s.Generation)
 	if err != nil {
@@ -55,7 +55,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if s.Generation == 2 {
-		err = driver.SetSecureBoot(s.VMName, enabeSecureBoot)
+		err = driver.SetSecureBoot(s.VMName, enableSecureBoot)
 		if err != nil {
 			err := fmt.Errorf("Error setting secure boot: %s", err)
 			state.Put("error", err)

--- a/builder/hyperv/common/step_create_vm.go
+++ b/builder/hyperv/common/step_create_vm.go
@@ -22,6 +22,7 @@ type StepCreateVM struct {
 	Generation      uint
 	Cpu             uint
 	EnableSecureBoot bool
+	ExposeVirtualizationExtensions bool
 }
 
 func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
@@ -46,7 +47,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	err = driver.SetVirtualMachineCpu(s.VMName, s.Cpu)
+	err = driver.SetVirtualMachineCpu(s.VMName, s.Cpu, s.ExposeVirtualizationExtensions)
 	if err != nil {
 		err := fmt.Errorf("Error creating setting virtual machine cpu: %s", err)
 		state.Put("error", err)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -89,6 +89,7 @@ type Config struct {
 	Cpu              uint     `mapstructure:"cpu"`
 	Generation       uint     `mapstructure:"generation"`
 	EnableSecureBoot bool     `mapstructure:"enable_secure_boot"`
+	EnableVirtualizationExtensions `mapstructure:"enable_virtualization_extensions`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -298,6 +299,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Generation:      b.config.Generation,
 			Cpu:             b.config.Cpu,
 			EnableSecureBoot: b.config.EnableSecureBoot,
+			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -89,7 +89,7 @@ type Config struct {
 	Cpu              uint     `mapstructure:"cpu"`
 	Generation       uint     `mapstructure:"generation"`
 	EnableSecureBoot bool     `mapstructure:"enable_secure_boot"`
-	EnableVirtualizationExtensions `mapstructure:"enable_virtualization_extensions`
+	EnableVirtualizationExtensions bool `mapstructure:"enable_virtualization_extensions"`
 
 	Communicator string `mapstructure:"communicator"`
 
@@ -299,7 +299,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			Generation:      b.config.Generation,
 			Cpu:             b.config.Cpu,
 			EnableSecureBoot: b.config.EnableSecureBoot,
-			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions
+			EnableVirtualizationExtensions: b.config.EnableVirtualizationExtensions,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -297,7 +297,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			DiskSize:        b.config.DiskSize,
 			Generation:      b.config.Generation,
 			Cpu:             b.config.Cpu,
-			EnabeSecureBoot: b.config.EnableSecureBoot,
+			EnableSecureBoot: b.config.EnableSecureBoot,
 		},
 		&hypervcommon.StepEnableIntegrationService{},
 

--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -220,12 +220,13 @@ New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHD
 func SetVirtualMachineCpu(vmName string, cpu uint, enableVirtualizationExtensions bool) error {
 
 	var script = `
-param([string]$vmName, [int]$cpu, [bool]$exposeVirtualizationExtensions)
-Set-VMProcessor -VMName $vmName -Count $cpu -exposeVirtualizationExtensions $exposeVirtualizationExtensions
+param([string]$vmName, [int]$cpu, [string]$exposeVirtualizationExtensions)
+$nested = [System.Boolean]::Parse($exposeVirtualizationExtensions)
+Set-VMProcessor -VMName $vmName -Count $cpu -exposeVirtualizationExtensions $nested
 `
-	exposeVirtualizationExtensionsString := "$False"
+	exposeVirtualizationExtensionsString := "False"
 	if enableVirtualizationExtensions {
-		exposeVirtualizationExtensionsString = "$True"
+		exposeVirtualizationExtensionsString = "True"
 	} 
 	var ps powershell.PowerShellCmd
 	err := ps.Run(script, vmName, strconv.FormatInt(int64(cpu), 10), exposeVirtualizationExtensionsString)

--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -217,11 +217,11 @@ New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHD
 	}
 }
 
-func SetVirtualMachineCpu(vmName string, cpu uint) error {
+func SetVirtualMachineCpu(vmName string, cpu uint, exposeVirtualizationExtensions bool) error {
 
 	var script = `
-param([string]$vmName, [int]$cpu)
-Set-VMProcessor -VMName $vmName -Count $cpu
+param([string]$vmName, [int]$cpu, [bool]$exposeVirtualizationExtensions)
+Set-VMProcessor -VMName $vmName -Count $cpu -exposeVirtualizationExtensions $exposeVirtualizationExtensions
 `
 
 	var ps powershell.PowerShellCmd

--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -223,9 +223,9 @@ func SetVirtualMachineCpu(vmName string, cpu uint, enableVirtualizationExtension
 param([string]$vmName, [int]$cpu, [bool]$exposeVirtualizationExtensions)
 Set-VMProcessor -VMName $vmName -Count $cpu -exposeVirtualizationExtensions $exposeVirtualizationExtensions
 `
-	exposeVirtualizationExtensionsString := "$false"
+	exposeVirtualizationExtensionsString := "$False"
 	if enableVirtualizationExtensions {
-		exposeVirtualizationExtensionsString = "$true"
+		exposeVirtualizationExtensionsString = "$True"
 	} 
 	var ps powershell.PowerShellCmd
 	err := ps.Run(script, vmName, strconv.FormatInt(int64(cpu), 10), exposeVirtualizationExtensionsString)

--- a/powershell/hyperv/hyperv.go
+++ b/powershell/hyperv/hyperv.go
@@ -217,15 +217,18 @@ New-VM -Name $vmName -Path $path -MemoryStartupBytes $memoryStartupBytes -NewVHD
 	}
 }
 
-func SetVirtualMachineCpu(vmName string, cpu uint, exposeVirtualizationExtensions bool) error {
+func SetVirtualMachineCpu(vmName string, cpu uint, enableVirtualizationExtensions bool) error {
 
 	var script = `
 param([string]$vmName, [int]$cpu, [bool]$exposeVirtualizationExtensions)
 Set-VMProcessor -VMName $vmName -Count $cpu -exposeVirtualizationExtensions $exposeVirtualizationExtensions
 `
-
+	exposeVirtualizationExtensionsString := "$false"
+	if enableVirtualizationExtensions {
+		exposeVirtualizationExtensionsString = "$true"
+	} 
 	var ps powershell.PowerShellCmd
-	err := ps.Run(script, vmName, strconv.FormatInt(int64(cpu), 10))
+	err := ps.Run(script, vmName, strconv.FormatInt(int64(cpu), 10), exposeVirtualizationExtensionsString)
 	return err
 }
 


### PR DESCRIPTION
Adds enable_virtualization_extensions to hyperv-iso builder. I chose enable_virtualization_extensions rather than "expose" to be more consistent with the other builder options. This was tested to work with https://github.com/PatrickLang/packer-windows/blob/shorterinstall/windows_2016_docker.json 
