### PR TITLE
Enable VlanID

### DIFF
--- a/builder/hyperv/common/step_configure_vlan.go
+++ b/builder/hyperv/common/step_configure_vlan.go
@@ -11,7 +11,7 @@ import (
 )
 
 type StepConfigureVlan struct {
-	vlanId string
+	VlanID string
 }
 
 func (s *StepConfigureVlan) Run(state multistep.StateBag) multistep.StepAction {
@@ -24,10 +24,11 @@ func (s *StepConfigureVlan) Run(state multistep.StateBag) multistep.StepAction {
 
 	ui.Say("Configuring vlan...")
 
-	vlanId := s.vlanId
+	vlanId := s.VlanID
 
 	if vlanId == "" {
-		vlanId = "1724"
+		// If no vlan ID is specified, do not enable Virtual LAN Identification
+		return multistep.ActionContinue
 	}
 
 	err := driver.SetNetworkAdapterVlanId(switchName, vlanId)

--- a/builder/hyperv/iso/builder.go
+++ b/builder/hyperv/iso/builder.go
@@ -87,6 +87,7 @@ type Config struct {
 
 	BootCommand                    []string `mapstructure:"boot_command"`
 	SwitchName                     string   `mapstructure:"switch_name"`
+	VlandID                        string   `mapstructure:"vlan_id"`
 	Cpu                            uint     `mapstructure:"cpu"`
 	Generation                     uint     `mapstructure:"generation"`
 	EnableMacSpoofing              bool     `mapstructure:"enable_mac_spoofing"`
@@ -352,6 +353,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&hypervcommon.StepMountSecondaryDvdImages{
 			IsoPaths:   b.config.SecondaryDvdImages,
 			Generation: b.config.Generation,
+		},
+		
+		&hypervcommon.StepConfigureVlan{
+			VlanID: b.config.VlandID,
 		},
 
 		&hypervcommon.StepRun{


### PR DESCRIPTION
Added StepConfigureVlan to builder.
Modified StepConfigureVlan to return multistep.ActionContinue if VlanID is not set.

Tested on our Windows Server 2012R2
